### PR TITLE
Fixed to work with my kdevelop 5.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.16)
+set(CMAKE_CXX_STANDARD 20)
 
 project(kdevcargo)
 

--- a/src/cargoplugin.h
+++ b/src/cargoplugin.h
@@ -89,6 +89,8 @@ public:
     bool removeTarget( KDevelop::ProjectTargetItem* target ) override;
     QList<KDevelop::ProjectTargetItem*> targets( KDevelop::ProjectFolderItem* ) const override;
 
+    virtual KDevelop::Path compiler(KDevelop::ProjectTargetItem* p) const final { return {}; }
+
 #if KDEVPLATFORM_VERSION >= VERSION_5_2
     QString extraArguments(KDevelop::ProjectBaseItem* item) const override;
 #endif


### PR DESCRIPTION
I know this project is 5 years, old, but it was what i needed.
Fixed the build for my kdev version

 - Changed cxx standard to 20, though 17 should work too.
 - Added a missing override function (stubbed).